### PR TITLE
Added loading of more than 25 API resources using _links.next.href

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,50 @@ var request = require('./lib/utils').request;
 
 module.exports = Client;
 
+/**
+ * Wrapper for request() to handle continued responses by loading the
+ * _links.next.href link and appending results to _links.item and
+ * _embedded.item.
+ */
+function requestWithContinuation(options, initialResult) {
+  return request(options)
+  .then(function (result) {
+    if (initialResult) {
+      // Combine loaded results to the initial result
+      if (initialResult._links && initialResult._links.item && result._links && result._links.item) {
+        if (!Array.isArray(initialResult._links.item)) {
+          initialResult._links.item = [initialResult._links.item];
+        }
+        if (!Array.isArray(result._links.item)) {
+          result._links.item = [result._links.item];
+        }
+        initialResult._links.item = initialResult._links.item.concat(result._links.item);
+      }
+      if (initialResult._embedded && initialResult._embedded.item && result._embedded && result._embedded.item) {
+        if (!Array.isArray(initialResult._embedded.item)) {
+          initialResult._embedded.item = [initialResult._embedded.item];
+        }
+        if (!Array.isArray(result._embedded.item)) {
+          result._embedded.item = [result._embedded.item];
+        }
+        initialResult._embedded.item = initialResult._embedded.item.concat(result._embedded.item);
+      }
+    } else {
+      // This was the first result
+      initialResult = result;
+    }
+    var nextHref = result._links && result._links.next && result._links.next.href;
+    if (nextHref) {
+      // Load next set of results using the next href
+      options.path = nextHref;
+      return requestWithContinuation(options, initialResult);
+    } else {
+      // Everything is now loaded
+      return initialResult;
+    }
+  });
+}
+
 function Client(options) {
   this.options = options;
 }
@@ -52,7 +96,7 @@ Client.prototype.listResources = function(restApiId) {
   this.options.method = 'GET';
   this.options.path = '/restapis/' + restApiId + '/resources';
   this.options.body = null;
-  return request(this.options);
+  return requestWithContinuation(this.options);
 };
 
 Client.prototype.createResource = function(restApiId, resourceParentId, pathPart) {
@@ -184,4 +228,3 @@ Client.prototype.listDeployments = function(restApiId) {
   this.options.body = null;
   return request(this.options);
 };
-


### PR DESCRIPTION
Here is a simple fix for loading 25+ API resources. Currently the client ignores everything after the first 25, causing all sorts of weird problems.
